### PR TITLE
Convert `ping_rtt_std_deviation` to Seconds from nanoseconds

### DIFF
--- a/internal/collector/icmp_collector.go
+++ b/internal/collector/icmp_collector.go
@@ -221,7 +221,7 @@ func PingHandler() http.HandlerFunc {
 			metrics.MinGauge.Set(stats.MinRtt.Seconds())
 			metrics.AvgGauge.Set(stats.AvgRtt.Seconds())
 			metrics.MaxGauge.Set(stats.MaxRtt.Seconds())
-			metrics.StddevGauge.Set(float64(stats.StdDevRtt))
+			metrics.StddevGauge.Set(stats.StdDevRtt.Seconds())
 			metrics.LossGauge.Set(stats.PacketLoss)
 			metrics.ProbeDurationGauge.Set(time.Since(start).Seconds())
 		}


### PR DESCRIPTION
Addresses #6.  All other metrics are in seconds, this makes all of them consistent.